### PR TITLE
Add ability to embed into existing cassandra distribution

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -254,6 +254,12 @@
 			<fileset dir="${resources}/solr" includes="solrconfig.xml,schema.xml" />
 		</copy>
 
+		<copy todir="${cassandra}/bin" overwrite="false">
+			<fileset dir="${resources}/cassandra" includes="*.cml" />
+		</copy>
+
+
+
 		<replace file="${cassandra}/bin/cassandra">
 			<replacetoken>
 				<![CDATA[classname="org.apache.cassandra.thrift.CassandraDaemon"]]>


### PR DESCRIPTION
Hey Jake,
  Re-building our already heavily scripted cassandra deployments wasn't really an option for us.  So, I've created an ant task and a class that will allow the user to add the solandra distribution to the cassandra system.  You'll only want to merge the last 2 commits.  Sorry I didn't have time to rebase into a new branch.
