### PR TITLE
deleteByQuery may have a bug

### DIFF
--- a/test/solandra/SolandraTests.java
+++ b/test/solandra/SolandraTests.java
@@ -429,6 +429,22 @@ public class SolandraTests
         QueryResponse r = solrClient.query(q);
         assertEquals(3, r.getResults().getNumFound());
 
+        // Try to check whether the document should be saved just after deleteById
+        SolrInputDocument doc = new SolrInputDocument();
+
+        doc.addField("title", "test4");
+        doc.addField("url", "http://www.test4.com");
+        doc.addField("text", "this is a test4 of Solandra");
+        doc.addField("user_id_i", 100);
+        doc.addField("price", 10);
+
+        solrClient.add(doc);
+
+        QueryResponse r2 = solrClient.query(q);
+        assertEquals(4, r2.getResults().getNumFound());
+
+        solrClient.deleteById("http://www.test4.com");
+        solrClient.commit(true, true);
     }
 
     public void testUpdateDocument(CommonsHttpSolrServer solrClient) throws Exception
@@ -467,6 +483,21 @@ public class SolandraTests
         QueryResponse r = solrClient.query(q);
 
         assertEquals(0, r.getResults().getNumFound());
+
+        // Try to check whether the document should be saved just after deleteByQuery
+        SolrInputDocument doc = new SolrInputDocument();
+        doc.addField("title", "test1");
+        doc.addField("url", "http://www.test.com");
+        doc.addField("text", "this is a test of Solandra");
+        doc.addField("user_id_i", 10);
+        doc.addField("price", 1000);
+
+        solrClient.add(doc);
+        solrClient.commit(true, true);
+
+        QueryResponse r2 = solrClient.query(q);
+
+        assertEquals(1, r2.getResults().getNumFound());
     }
     
     public void testQueryFilter(CommonsHttpSolrServer solrClient) throws Exception


### PR DESCRIPTION
Hi tjake,

I tried to clean all documents in solandra with delete_by_query in ruby client, and it looked working with no documents returned, but after that, I can't add the document with the same id.

I'm not Java guy, so this pull request is written just for adding the tests which will fail, but it should work, I believe.

Thanks,
-- Takeshi
