### PR TITLE
Change CassandraDaemon to decrement latch after finished with Cassandra s

### DIFF
--- a/src/lucandra/CassandraDaemon.java
+++ b/src/lucandra/CassandraDaemon.java
@@ -28,11 +28,8 @@ public class CassandraDaemon extends org.apache.cassandra.thrift.CassandraDaemon
     
     public void start()
     {
-        
-        startedLatch.countDown();
-        
-        // TODO Auto-generated method stub
         super.start();
+        startedLatch.countDown();
     }
 
     public CountDownLatch getStartedLatch()


### PR DESCRIPTION
Hi tjake,

I'm Chris Nauroth.  I'm a software engineer at Disney working on a project that integrates with Solandra.  I think you've spoken with Arun Jacob.  I'm a colleague of his.  We're really excited about Solandra, and it's been working great for us so far in a test environment.

I'd like to submit a few patches for your consideration.  This is the first one.  CassandraUtils.startupServer starts a CassandraDaemon, and then waits on a CountDownLatch for notification that Cassandra initialization has completed.  I have some automated integration tests that were sporadically returning from CassandraUtils.startupServer before Cassandra startup had really finished.  This patch fixes the issue by reordering some code in CassandraDaemon.java so that it decrements the latch after Cassandra completes initialization (not before).

Thanks,
--Chris
