### PR TITLE
Add stopServer method to CassandraUtils.java.  This is useful in scenario

### DIFF
--- a/src/lucandra/CassandraUtils.java
+++ b/src/lucandra/CassandraUtils.java
@@ -188,6 +188,8 @@ public class CassandraUtils
    
     private static boolean               cassandraStarted       = false;
 
+    private static CassandraDaemon       daemon                 = null;
+
     public static String                 fakeToken              = String.valueOf(System.nanoTime());
 
     public static synchronized void setStartup()
@@ -250,7 +252,7 @@ public class CassandraUtils
 
         System.setProperty("cassandra-foreground", "1");
 
-        final CassandraDaemon daemon = new CassandraDaemon();
+        daemon = new CassandraDaemon();
 
         try
         {
@@ -282,6 +284,16 @@ public class CassandraUtils
             logger.error("Cassandra not started after 1 hour");
             System.exit(3);
         }
+    }
+
+    public static synchronized void stopServer()
+    {
+        if (!cassandraStarted)
+            return;
+
+        daemon.deactivate();
+        daemon = null;
+        cassandraStarted = false;
     }
 
     public static void createCassandraSchema() throws IOException


### PR DESCRIPTION
This change adds a stopServer method to CassandraUtils.java.  Before this change, there was no way for client code to access the CassandraDaemon that was started by a call to CassandraUtils.startupServer and guarantee a graceful shutdown.

I found this problematic for automated integration tests running on Windows.  We need to delete the /tmp/cassandra-data directory between test suite runs to guarantee a clean slate.  On Windows, Cassandra would hold a file lock on the commit log, preventing the test suite from deleting it.  With this new method in place, a test suite can call CassandraUtils.stopServer, wait for a graceful shutdown of Cassandra, and then delete /tmp/cassandra-data without lock contention.

Thanks,
--Chris
