### PR TITLE
Issue #73: replace occurrences of hard-coded port 8983 with the configure

### DIFF
--- a/resources/solandra.properties
+++ b/resources/solandra.properties
@@ -37,6 +37,10 @@ solandra.write.buffer.queue.size = 16
 #keyspace name for solandra
 solandra.keyspace = L
 
+#The port number that the Solandra server uses to listen for client requests.
+#If unspecified, then the default is 8983.
+solandra.port = 8983
+
 #The number of retries solandra will attempt before 
 #failing a write or read (TimeoutException)
 cassandra.retries = 1024

--- a/src/lucandra/CassandraUtils.java
+++ b/src/lucandra/CassandraUtils.java
@@ -67,7 +67,7 @@ public class CassandraUtils
     public static final ConsistencyLevel consistency;
     
     public static boolean useCompression;
-
+    public static int port;
     
     // Initialize logging in such a way that it checks for config changes every
     // 10 seconds.
@@ -112,6 +112,7 @@ public class CassandraUtils
                     .name()));
             
             useCompression = Boolean.valueOf(properties.getProperty("solandra.compression", "true"));
+            port = Integer.parseInt(properties.getProperty("solandra.port", "8983"));
             
             try
             {

--- a/src/solandra/SolandraComponent.java
+++ b/src/solandra/SolandraComponent.java
@@ -50,6 +50,7 @@ public final class SolandraComponent
     private static AtomicBoolean hasSolandraSchema = new AtomicBoolean(false);
     private static final Logger logger = Logger.getLogger(SolandraComponent.class);
     public final static Map<String,Long> cacheCheck = new MapMaker().makeMap();
+    private static final int port = Integer.parseInt(System.getProperty("solandra.port", "8983"));
 
     public static boolean flushCache(String indexName) throws IOException
     {   
@@ -165,7 +166,7 @@ public final class SolandraComponent
                     throw new IOException("can't locate index");
 
                 InetAddress addr = endpoints.get(0);
-                String shard = addr.getHostAddress() + ":8983/solandra/" + indexName + "~" + i;
+                String shard = addr.getHostAddress() + ":" + port + "/solandra/" + indexName + "~" + i;
 
                 if(logger.isDebugEnabled())
                     logger.debug("Adding shard(" + indexName + "): " + shard);

--- a/src/solandra/SolandraComponent.java
+++ b/src/solandra/SolandraComponent.java
@@ -50,7 +50,6 @@ public final class SolandraComponent
     private static AtomicBoolean hasSolandraSchema = new AtomicBoolean(false);
     private static final Logger logger = Logger.getLogger(SolandraComponent.class);
     public final static Map<String,Long> cacheCheck = new MapMaker().makeMap();
-    private static final int port = Integer.parseInt(System.getProperty("solandra.port", "8983"));
 
     public static boolean flushCache(String indexName) throws IOException
     {   
@@ -166,7 +165,7 @@ public final class SolandraComponent
                     throw new IOException("can't locate index");
 
                 InetAddress addr = endpoints.get(0);
-                String shard = addr.getHostAddress() + ":" + port + "/solandra/" + indexName + "~" + i;
+                String shard = addr.getHostAddress() + ":" + CassandraUtils.port + "/solandra/" + indexName + "~" + i;
 
                 if(logger.isDebugEnabled())
                     logger.debug("Adding shard(" + indexName + "): " + shard);

--- a/src/solandra/SolandraIndexWriter.java
+++ b/src/solandra/SolandraIndexWriter.java
@@ -109,6 +109,8 @@ public class SolandraIndexWriter extends UpdateHandler
                                                                                                                       "solandra.write.buffer.queue.size",
                                                                                                                       "16"));
 
+    private static final int port = Integer.parseInt(System.getProperty("solandra.port", "8983"));
+
     public SolandraIndexWriter(SolrCore core)
     {
         super(core);
@@ -460,7 +462,7 @@ public class SolandraIndexWriter extends UpdateHandler
                     {
                         // delete from other shards via http
                         CommonsHttpSolrServer solrj = new CommonsHttpSolrServer("http://" + addr.getHostAddress()
-                                + ":8983/solandra/" + subIndex, new HttpClient(httpConnections));
+                                + ":" + port + "/solandra/" + subIndex, new HttpClient(httpConnections));
 
                         try
                         {

--- a/src/solandra/SolandraIndexWriter.java
+++ b/src/solandra/SolandraIndexWriter.java
@@ -109,8 +109,6 @@ public class SolandraIndexWriter extends UpdateHandler
                                                                                                                       "solandra.write.buffer.queue.size",
                                                                                                                       "16"));
 
-    private static final int port = Integer.parseInt(System.getProperty("solandra.port", "8983"));
-
     public SolandraIndexWriter(SolrCore core)
     {
         super(core);
@@ -462,7 +460,7 @@ public class SolandraIndexWriter extends UpdateHandler
                     {
                         // delete from other shards via http
                         CommonsHttpSolrServer solrj = new CommonsHttpSolrServer("http://" + addr.getHostAddress()
-                                + ":" + port + "/solandra/" + subIndex, new HttpClient(httpConnections));
+                                + ":" + CassandraUtils.port + "/solandra/" + subIndex, new HttpClient(httpConnections));
 
                         try
                         {

--- a/src/solandra/SolandraServer.java
+++ b/src/solandra/SolandraServer.java
@@ -31,8 +31,6 @@ public class SolandraServer {
 
 		String context = System.getProperty("solandra.context", "/solandra");
 		
-		int port = Integer.parseInt(System.getProperty("solandra.port", "8983"));
-		
 		try {
 		    
 		    if(System.getProperty("solandra.clientmode", "false").equalsIgnoreCase("true"))
@@ -40,7 +38,7 @@ public class SolandraServer {
 		    else
 		        CassandraUtils.startupServer();
 
-			JettySolandraRunner jetty = new JettySolandraRunner(context, port);
+			JettySolandraRunner jetty = new JettySolandraRunner(context, CassandraUtils.port);
 			jetty.start(false);
 		} catch (Exception ex) {
 			ex.printStackTrace();


### PR DESCRIPTION
I'd like to be able to start up Solandra on an alternative port.  This is a patch that replaces a few occurrences of a hard-coded port 8983 with a lookup of the solandra.port system property.  This addresses issue #73:

https://github.com/tjake/Solandra/issues/73

Thanks,
--Chris
