### PR TITLE
Fix issue where a POST/GET to 'solandra/schemas/...' would be interpreted as a valid url, but would not properly create the core.

### DIFF
--- a/src/solandra/SolandraDispatchFilter.java
+++ b/src/solandra/SolandraDispatchFilter.java
@@ -60,7 +60,7 @@ public class SolandraDispatchFilter extends SolrDispatchFilter
 
             // otherwise, we should find a index from the path
             int idx = path.indexOf("/", 1);
-            if (idx > 1)
+            if (idx == schemaPrefix.length)
             {
                 // try to get the index as a request parameter first
                 indexName = path.substring(1, idx);


### PR DESCRIPTION
Any single trailing character to 'schema' would produce the mistaken result of success.
